### PR TITLE
Add leptos_i18n

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ A collection of awesome libraries in the Leptos ecosystem.
 - [Papelito](https://github.com/msmaiaa/papelito) A simple WYSIWYG editor for leptos.
 - [leptos-server-signal](https://github.com/tqwewe/leptos_server_signal) Leptos signals kept in sync with the server through websockets.
 - [leptos_sse](https://github.com/messense/leptos_sse) Leptos server signals synced through Server-Sent-Events (SSE).
+- [leptos_i18n](https://github.com/Baptistemontan/leptos_i18n) A translation library for Leptos.
 
 ## Blogs / Websites
 - [leptos.dev](https://leptos.dev) The official Leptos website, built with Leptos (of course.)


### PR DESCRIPTION
Leptos i18n is a library whose goal is to keep translations as easy as possible to integrate in a Leptos application and use macros to load and parse the translations at compile time. 