### PR TITLE
Add `leptos-obfuscate`

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ A collection of awesome libraries in the Leptos ecosystem.
 - [leptos_darkmode](https://gitlab.com/kerkmann/leptos_darkmode) A Darkmode Helper which adds the `dark` class for Tailwind CSS, based on the local storage or media profile.
 - [leptos_oidc](https://gitlab.com/kerkmann/leptos_oidc) A Leptos utility library for simplified OpenID Connect (OIDC) authentication integration.
 - [leptos_meilisearch](https://gitlab.com/kerkmann/leptos_meilisearch) A Leptos integration for [meilisearch](https://www.meilisearch.com/), wrapping them in a `Resource` and helps with useful helper functions und utils.
+- [leptos-obfuscate](https://github.com/sebadob/leptos-obfuscate) Tiny crate with a Leptos component for obfuscating email addresses for bot and spam protection
 
 ## Blogs / Websites
 - [leptos.dev](https://leptos.dev) The official Leptos website, built with Leptos (of course.)

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ A collection of awesome libraries in the Leptos ecosystem.
 - [leptos_oidc](https://gitlab.com/kerkmann/leptos_oidc) A Leptos utility library for simplified OpenID Connect (OIDC) authentication integration.
 - [leptos_meilisearch](https://gitlab.com/kerkmann/leptos_meilisearch) A Leptos integration for [meilisearch](https://www.meilisearch.com/), wrapping them in a `Resource` and helps with useful helper functions und utils.
 - [leptos-captcha](https://github.com/sebadob/leptos-captcha) Simple, fully self-hosted Captcha / PoW component for Leptos without any user interaction.
+- [leptos-obfuscate](https://github.com/sebadob/leptos-obfuscate) Tiny crate with a Leptos component for obfuscating email addresses for bot and spam protection
 
 ## Blogs / Websites
 - [leptos.dev](https://leptos.dev) The official Leptos website, built with Leptos (of course.)


### PR DESCRIPTION
This is a tiny component I just created for email address obfuscation for bot and spam protection.
You can provide a honeypot link / address, if you like as well.

Available on crates.io of course [leptos-obfuscate](https://crates.io/crates/leptos-obfuscate)