### PR TITLE
Add leptos-workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A collection of awesome libraries in the Leptos ecosystem.
 
 - [leptos-fullstack](https://github.com/srid/leptos-fullstack) - A [Nix](https://nixos.org/) template for full-stack web apps in Rust using Leptos + Tailwind
 
-- [leptos-workers](https://github.com/BrandonDyer64/leptos-workers) - Starter template for use with Leptos in a [Cloudflare Worker](https://developers.cloudflare.com/workers/)
+- [leptos-workers](https://github.com/BrandonDyer64/leptos-workers) - Starter template for use with Leptos in [Cloudflare Workers](https://developers.cloudflare.com/workers/)
 
 ## Styling and Design
 - [Stylers](https://github.com/abishekatp/stylers) Compile-time scoped CSS extracted from Leptos components

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ A collection of awesome libraries in the Leptos ecosystem.
 ### Unofficial
 
 - [leptos-fullstack](https://github.com/srid/leptos-fullstack) - A [Nix](https://nixos.org/) template for full-stack web apps in Rust using Leptos + Tailwind
-- [leptos-workers](https://github.com/BrandonDyer64/leptos-workers) - Starter template for use with Leptos in a Cloudflare Worker
+
+- [leptos-workers](https://github.com/BrandonDyer64/leptos-workers) - Starter template for use with Leptos in a [Cloudflare Worker](https://developers.cloudflare.com/workers/)
 
 ## Styling and Design
 - [Stylers](https://github.com/abishekatp/stylers) Compile-time scoped CSS extracted from Leptos components

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ A collection of awesome libraries in the Leptos ecosystem.
 ### Unofficial
 
 - [leptos-fullstack](https://github.com/srid/leptos-fullstack) - A [Nix](https://nixos.org/) template for full-stack web apps in Rust using Leptos + Tailwind
+- [leptos-workers](https://github.com/BrandonDyer64/leptos-workers) - Starter template for use with Leptos in a Cloudflare Worker
 
 ## Styling and Design
 - [Stylers](https://github.com/abishekatp/stylers) Compile-time scoped CSS extracted from Leptos components


### PR DESCRIPTION
A template for using Leptos in Cloudflare Workers. Batteries included. Can deploy directly to Cloudflare and use all of their goodies.

I am not from Cloudflare. I had quite a bit of trouble with Leptos in Workers and eventually got it working, so I thought I'd make a template that works out of the box.