### PR TITLE
Add leptos-material, a component library.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ full-stack web applications using Rust.
   Easily create powerful tables from structs.
 - [leptix](https://github.com/leptix/leptix) Accessible and unstyled components
   for Leptos.
+- [leptos-material](https://github.com/jordi-star/leptos-material) A leptos component wrapper for [Material Web Components](https://material-web.dev/), along with some extra components to fill in the gaps.
 
 ## Libraries
 


### PR DESCRIPTION
This library automatically builds and bundles the [Material Web Components](https://material-web.dev/). It includes Leptos component wrappers for the components, as well as some native Leptos components to fill in the gaps, such as Cards and Datepickers.