### PR TITLE
Add Antigravity SDK and goldcoders.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ full-stack web applications using Rust.
 
 - [tauri-leptos-ssr](https://github.com/codeitlikemiley/tauri-leptos-ssr) - ⚡ Tauri + Leptos SSR starter template , Build native desktop apps with server-side rendering, all in Rust.
 
+- [antigravity-sdk-rust](https://github.com/codeitlikemiley/antigravity-sdk-rust) - A Rust library for building AI agents with Gemini. Includes Leptos examples demonstrating how to integrate agentic workflows into Leptos web applications.
+
 ## Styling and Design
 
 - [Stylers](https://github.com/abishekatp/stylers) Compile-time scoped CSS
@@ -217,4 +219,4 @@ full-stack web applications using Rust.
 - [osynic-osuapi.deno.dev](https://osynic-osuapi.deno.dev/) Beautiful, modern [OsynicOsuapi](https://github.com/osynicite/osynic_osuapi) demo website. Deployed on Deno Deploy. Built with Leptos CSR + TailwindCSS + Lucide Leptos + Leptos Fluent + Osynic Osuapi ([github](https://github.com/islatri/leptos_osuapi_playground))
 - [SQLite Playground](https://sqlight.dev) A SQLite Playground that runs completely locally. Built with Leptos CSR. ([github](https://github.com/Spxg/sqlight))
 - [ccf-deadlines](https://ccfddl.com) Collaboratively track worldwide conference deadlines. Built with Leptos CSR and thaw-ui. ([github](https://github.com/ccfddl/ccf-deadlines))
-
+- [goldcoders.dev](https://goldcoders.dev) - Professional system automation and software engineering. Built with Leptos.


### PR DESCRIPTION
This PR adds the following resources to the Awesome Leptos list:

1. **antigravity-sdk-rust** under the Unofficial Starter Templates/Projects section: A Rust library/SDK ported from Python for building stateful, scalable AI agents powered by Antigravity and Gemini. It includes complete starter examples for Leptos SSR with both Leptos Spin (Wasm/WASI serverless) and Leptos Axum.
2. **goldcoders.dev** under the Blogs / Websites section: A professional system automation and software engineering consultancy website built with Leptos.